### PR TITLE
Make Touch ID setup optional for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ More P.S.E.U.D.O. documentation is coming soon...
 ## Screenshots
 
 __Automatically opening and focusing the user to enable Touch ID.__
+Set `TOUCH_ID_OPTIONAL` to True to make this optional.
 
 ![Start to enable Touch ID via `pseudo`](https://github.com/Macjutsu/pseudo/blob/main/Pseudo-Screen-Captures/Touch-ID-Start.jpg)
 

--- a/pseudo
+++ b/pseudo
@@ -32,6 +32,10 @@ set_defaults() {
 	DISPLAY_DIALOG_POSITION="topright"
 	readonly DISPLAY_DIALOG_POSITION
 	
+	# Make Touch ID setup optional for users. Set to "TRUE" to allow users to skip Touch ID setup, or "FALSE" to require it.
+	TOUCH_ID_OPTIONAL="TRUE"
+	readonly TOUCH_ID_OPTIONAL
+	
 	# Path to the log for the main pseudo workflow:
 	PSEUDO_LOG="/var/log/pseudo.log"
 	readonly PSEUDO_LOG
@@ -393,13 +397,30 @@ end tell
 EOAS
 }
 
+# Open a swiftDialog asking the user if they want to enable Touch ID.
+open_dialog_touch_id_prompt() {
+	echo "quit:" >> "${SWIFT_DIALOG_COMMAND_FILE}"
+	sleep 0.1
+	"${SWIFT_DIALOG_BINARY}" \
+	--title "Touch ID Setup" \
+	--message "The Platform SSO experience is improved when used with your fingerprint reader. Would you like to enable Touch ID for this Mac?  \n  \nTouch ID provides enhanced security and convenience for authentication. \n \nYou can skip this step if your device doesn't have Touch ID or if you prefer not to set it up now." \
+	--icon "SF=touchid,colour=auto" \
+	--position "${DISPLAY_DIALOG_POSITION}" \
+	--button1text "Enable Touch ID" \
+	--button2text "Skip" \
+	--quitkey p \
+	--hidedefaultkeyboardaction \
+	--ontop
+	return $?
+}
+
 # Open a swiftDialog to inform the user that they need to enable Touch ID.
 open_dialog_touch_id_start() {
 	echo "quit:" >> "${SWIFT_DIALOG_COMMAND_FILE}"
 	sleep 0.1
 	"${SWIFT_DIALOG_BINARY}" \
-	--title "Touch ID Required" \
-	--message "Touch ID is required for all Mac computers at ${DISPLAY_ORGANIZATION_NAME}. Please enable Touch ID by adding at least one fingerprint." \
+	--title "Touch ID Setup" \
+	--message "Please enable Touch ID by adding at least one fingerprint using the System Settings window." \
 	--icon "SF=touchid,colour=auto" \
 	--style mini \
 	--position "${DISPLAY_DIALOG_POSITION}" \
@@ -431,6 +452,30 @@ open_dialog_touch_id_success() {
 # The full workflow to check Touch ID status and if required open interfaces and dialogs to enable Touch ID.
 workflow_touch_id() {
 	check_touch_id_user_status
+	
+	# If Touch ID is already enabled, skip the workflow
+	if [[ "${touch_id_user_status}" == "TRUE" ]]; then
+		log_pseudo "Status: Touch ID is already enabled for local user ${current_user_account_name} (${current_user_id})."
+		return 0
+	fi
+	
+	# Check if Touch ID is optional - if so, ask the user; if not, proceed directly to setup
+	if [[ "${TOUCH_ID_OPTIONAL}" == "TRUE" ]]; then
+		# Ask user if they want to enable Touch ID
+		open_dialog_touch_id_prompt
+		local dialog_exit_code=$?
+		
+		# If user clicked "Skip" (button 2), swiftDialog returns exit code 2
+		if [[ $dialog_exit_code -eq 2 ]]; then
+			log_pseudo "Status: User chose to skip Touch ID setup."
+			return 0
+		fi
+		
+		log_pseudo "Status: User chose to enable Touch ID."
+	else
+		log_pseudo "Status: Touch ID is required and will be configured for local user ${current_user_account_name} (${current_user_id})."
+	fi
+	
 	touch_id_workflow_timer=0
 	touch_id_workflow_active="FALSE"
 	while [[ "${touch_id_user_status}" == "FALSE" ]] || { [[ "${touch_id_user_status}" == "TRUE" ]] && [[ "$(check_touch_id_fingerprint_sheet_active)" == "TRUE" ]]; }; do
@@ -457,14 +502,10 @@ workflow_touch_id() {
 		check_touch_id_user_status
 		((touch_id_workflow_timer++))
 	done
-	if [[ "${touch_id_workflow_active}" == "TRUE" ]]; then
-		focus_touch_id_settings
-		open_dialog_touch_id_success
-		killall "System Settings" >/dev/null 2>&1
-		log_pseudo "Status: Touch ID is now enabled for local user ${current_user_account_name} (${current_user_id}). The workflow took ${touch_id_workflow_timer} seconds to complete."
-	else
-		log_pseudo "Status: Touch ID is already enabled for local user ${current_user_account_name} (${current_user_id})."
-	fi
+	focus_touch_id_settings
+	open_dialog_touch_id_success
+	killall "System Settings" >/dev/null 2>&1
+	log_pseudo "Status: Touch ID is now enabled for local user ${current_user_account_name} (${current_user_id}). The workflow took ${touch_id_workflow_timer} seconds to complete."
 }
 
 # MARK: *** Platform SSO Workflow ***


### PR DESCRIPTION
Added the TOUCH_ID_OPTIONAL variable to allow users to skip Touch ID setup if desired. Updated the workflow to prompt users when Touch ID is optional, and adjusted dialogs and logging accordingly. Updated README to document the new option.